### PR TITLE
Fix .onnx file loading fallback

### DIFF
--- a/AutoChar_v09.py
+++ b/AutoChar_v09.py
@@ -246,10 +246,9 @@ class Script(scripts.Script):
 
             # Load the model
 
-            try:
+            weights = os.path.join(directory, "face_detection_yunet_2023mar.onnx")
+            if os.path.isfile(weights) == False:
                 weights = os.path.join(directory, "face_detection_yunet_2022mar.onnx")
-            except:
-                weights = os.path.join(directory, "face_detection_yunet_2023mar.onnx")
                 
             face_detector = cv2.FaceDetectorYN_create(weights, "", (0, 0), face_confidence_threshold)
 


### PR DESCRIPTION
To fix the getLayerData error and a .onnx file not found error #12 

The original code will load the 2022 onnx file first. This doesn't seem to work with the new 2023 version of the plugin for whatever reason. 

But there is another error where if you don't have the 2022 onnx file downloaded, it will give a onnx file not found when running the `cv2.FaceDetectorYN_create` function. That's because os.path.join doesn't throw any exceptions, it just concatenates strings basically.

So I changed it to load the 2023 onnx first, then use isfile to validate if it exists, if 2023 doesn't then it will fallback to 2022. (2022 doesn't work for whatever reason with the getLayerData error, but it does properly fallback to 2022 if 2023 doesn't exist)